### PR TITLE
Should build libcoap examples for the resource directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,12 @@ Install python requirements, using virtualenv is reccomended
 sudo pip install -r requirements.txt
 ```
 
-Configure and build libcoap:
+Configure and build libcoap and its examples:
 ```sh
 cd pyotapp/appsTesting/libcoap-4.0.1/
 ./configure
+make
+cd examples
 make
 ```
 


### PR DESCRIPTION
Hi,

While testing I noticed you should also build the examples in libcoap, otherwise the resource directory won't function. This simple pull request updates the README to include this change.

Regards,
Floris
